### PR TITLE
Add Kaggle dataset download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ pip install -r requirements.txt
 streamlit run apps/streamlit_app.py --server.address 0.0.0.0 --server.port 8501
 uvicorn furniture_ai.api.server:app --host 0.0.0.0 --port 8000 --reload
 ```
+
+## Kaggle credentials and datasets
+
+Downloadable training data is hosted on Kaggle. Place your `kaggle.json`
+in the project root or `~/.kaggle/`, or export `KAGGLE_USERNAME` and
+`KAGGLE_KEY` before running scripts.
+
+`scripts/train_detector.py` can fetch a dataset automatically when you
+pass its slug:
+
+```bash
+python scripts/train_detector.py --dataset-slug user/dataset
+```
+
+If the target directory is empty the dataset is downloaded into
+`--data-root` and unzipped.

--- a/furniture_ai/config.py
+++ b/furniture_ai/config.py
@@ -17,6 +17,7 @@ class DetectorConfig(BaseModel):
     data_root: str = "data/detector"
     train_ann: str = "annotations/train.json"
     val_ann: str = "annotations/val.json"
+    dataset_slug: str | None = None
     img_size: int = 640
     batch_size: int = 16
     epochs: int = 50


### PR DESCRIPTION
## Summary
- allow configuring a `dataset_slug` for detector training
- verify Kaggle credentials and optionally download datasets automatically
- document required Kaggle credentials and `--dataset-slug` usage

## Testing
- `pytest`
- `python scripts/train_detector.py --help` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c2a446a08325966326c9a64a81fa