### PR TITLE
docs: add streamlit launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ streamlit run apps/streamlit_app.py --server.address 0.0.0.0 --server.port 8501
 uvicorn furniture_ai.api.server:app --host 0.0.0.0 --port 8000 --reload
 ```
 
+### Alternative ways to launch the Streamlit UI
+
+**Docker**
+
+```bash
+docker build -f Dockerfile.streamlit -t floorplan-furnisher-ui .
+docker run -p 8501:8501 floorplan-furnisher-ui
+```
+
+**Makefile**
+
+```bash
+make -f Makefile.make ui
+```
+
+> Adjust the segmenter model path in the sidebar or provide model weights so
+> `run_furnish` can locate `models/segmenter/best.pt`.
+
 ## Kaggle credentials and datasets
 
 Downloadable training data is hosted on Kaggle. Place your `kaggle.json`


### PR DESCRIPTION
## Summary
- document Docker and Makefile options for launching the Streamlit UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1c8a4d2d483258e434a0d5a3bfa8c